### PR TITLE
Bug Fix:  Base.xgb_model.booster() -->  Base.xgb_model.get_booster()

### DIFF
--- a/speedml/plot.py
+++ b/speedml/plot.py
@@ -144,5 +144,5 @@ class Plot(Base):
         X = Base.train_n
         X = X.drop([Base.target], axis=1)
         self._create_feature_map(X.columns)
-        fscore = Base.xgb_model.booster().get_fscore(fmap=Base._config['outpath'] + 'xgb.fmap')
+        fscore = Base.xgb_model.get_booster().get_fscore(fmap=Base._config['outpath'] + 'xgb.fmap')
         self._plot_importance(list(fscore.keys()), list(fscore.values()))


### PR DESCRIPTION
`Base.xgb_model.booster` returns a string, whilst `xgboost.sklearn.XGBClassifier.get_booster` returns a `xgboost.core.Booster` which can have `.get_fscore` applied.

This fixed a bug highlighted in `titanic-solution-using-speedml.ipynb` when the command `sml.plot.xgb_importance()` is run.