### PR TITLE
Bug Fix: Load path for testing data isn't absolute any more

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import pytest
 def sml():
     from speedml import Speedml
     sml = Speedml(
-        train = '/Users/manavsehgal/Developer/speedml/tests/data/train.csv',
-        test = '/Users/manavsehgal/Developer/speedml/tests/data/test.csv',
+        train = 'tests/data/train.csv',
+        test = 'tests/data/test.csv',
         target = 'Survived',
         uid = 'PassengerId')
     yield sml


### PR DESCRIPTION
The paths for test data are hard coded to `/Users/manavsehgal/Developer/speedml/tests/data/train.csv` rather then simply `tests/data/train.csv`.

`py.test` fails with the current set up (on anything but your personal machine), but passes for this pull request.